### PR TITLE
More configurable params

### DIFF
--- a/hparams.py
+++ b/hparams.py
@@ -20,6 +20,13 @@ hparams = tf.contrib.training.HParams(
   # Model:
   # TODO: add more configurable hparams
   outputs_per_step=5,
+  embed_depth=256,
+  prenet_depth1=256,
+  prenet_depth2=128,
+  encoder_depth=256,
+  postnet_depth=256,
+  attention_depth=256,
+  decoder_depth=256,
 
   # Training:
   batch_size=32,

--- a/models/rnn_wrappers.py
+++ b/models/rnn_wrappers.py
@@ -6,10 +6,11 @@ from .modules import prenet
 
 class DecoderPrenetWrapper(RNNCell):
   '''Runs RNN inputs through a prenet before sending them to the cell.'''
-  def __init__(self, cell, is_training):
+  def __init__(self, cell, is_training, h_params):
     super(DecoderPrenetWrapper, self).__init__()
     self._cell = cell
     self._is_training = is_training
+    self._h_params = h_params
 
   @property
   def state_size(self):
@@ -20,7 +21,8 @@ class DecoderPrenetWrapper(RNNCell):
     return self._cell.output_size
 
   def call(self, inputs, state):
-    prenet_out = prenet(inputs, self._is_training, scope='decoder_prenet')
+    prenet_out = prenet(inputs, self._is_training, self._h_params,
+                        scope='decoder_prenet')
     return self._cell(prenet_out, state)
 
   def zero_state(self, batch_size, dtype):


### PR DESCRIPTION
I verified:

- Original params print the same dimensions

- I set each depth to a unique number of channels, and verified it still runs. Can resume training, and run eval from previously-saved checkpoint.

