### PR TITLE
Update modules.py

### DIFF
--- a/models/modules.py
+++ b/models/modules.py
@@ -8,7 +8,7 @@ def prenet(inputs, is_training, layer_sizes=[256, 128], scope=None):
   with tf.variable_scope(scope or 'prenet'):
     for i, size in enumerate(layer_sizes):
       dense = tf.layers.dense(x, units=size, activation=tf.nn.relu, name='dense_%d' % (i+1))
-      x = tf.layers.dropout(dense, rate=drop_rate, name='dropout_%d' % (i+1))
+      x = tf.layers.dropout(dense, rate=drop_rate, training=True, name='dropout_%d' % (i+1))
   return x
 
 


### PR DESCRIPTION
prenet's dropout is active for both training and evaluation. Tacotron2 paper https://arxiv.org/pdf/1712.05884.pdf