### PR TITLE
Fix synthesis bug

### DIFF
--- a/synthesizer.py
+++ b/synthesizer.py
@@ -16,7 +16,6 @@ class Synthesizer:
     with tf.variable_scope('model') as scope:
       self.model = create_model(model_name, hparams)
       self.model.initialize(inputs, input_lengths)
-      self.wav_output = audio.inv_spectrogram_tensorflow(self.model.linear_outputs[0])
 
     print('Loading checkpoint: %s' % checkpoint_path)
     self.session = tf.Session()
@@ -32,8 +31,8 @@ class Synthesizer:
       self.model.inputs: [np.asarray(seq, dtype=np.int32)],
       self.model.input_lengths: np.asarray([len(seq)], dtype=np.int32)
     }
-    wav = self.session.run(self.wav_output, feed_dict=feed_dict)
-    wav = audio.inv_preemphasis(wav)
+    linears = self.session.run(self.model.linear_outputs[0], feed_dict=feed_dict)
+    wav = audio.inv_spectrogram(linears.T)
     wav = wav[:audio.find_endpoint(wav)]
     out = io.BytesIO()
     audio.save_wav(wav, out)


### PR DESCRIPTION
Use `inv_spectrogram` method instead of `inv_spectrogram_tensorflow`, and the synthesis would be steady for all sentences.