### PR TITLE
Mask memory with zeros for values past the encoder sequence lengths

### DIFF
--- a/models/tacotron.py
+++ b/models/tacotron.py
@@ -50,7 +50,8 @@ class Tacotron():
       # Attention
       attention_cell = AttentionWrapper(
         GRUCell(hp.attention_depth),
-        BahdanauAttention(hp.attention_depth, encoder_outputs),
+        BahdanauAttention(hp.attention_depth, encoder_outputs,
+                          memory_sequence_length=input_lengths),
         alignment_history=True,
         output_attention=False)                                                  # [N, T_in, attention_depth=256]
       


### PR DESCRIPTION
I think maybe it's more appropriate to mask the padding values of the encoder memory to make alignments easier to learn.